### PR TITLE
fix: date input responsiveness

### DIFF
--- a/src/pages/Transaction/View/TransactionsView.tsx
+++ b/src/pages/Transaction/View/TransactionsView.tsx
@@ -70,6 +70,7 @@ export function TransactionsView() {
             _focus={{
               borderColor: "primary.300",
             }}
+            value={transactionsQueryDates.fromDate.toISOString().split("T")[0]}
             onChange={handleChangeBaseDate}
           />
         </HStack>


### PR DESCRIPTION
This implementation put an initial value into the date input on transactions page. The idea is to avoid cenarios where the input is empty and weird (small).