### PR TITLE
feat: edit installment transactions

### DIFF
--- a/src/contexts/TransactionsViewContext/TransactionsViewContext.types.ts
+++ b/src/contexts/TransactionsViewContext/TransactionsViewContext.types.ts
@@ -50,6 +50,8 @@ export interface Transaction {
   name: string;
   ref: DocumentRef;
   transactionRefId?: string;
+  installmentAmount?: number;
+  installmentOrder?: number;
 }
 
 interface DocumentRef {

--- a/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.tsx
+++ b/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.tsx
@@ -64,7 +64,17 @@ export function TransactionRow({ transaction, onRemove }: TransactionRowProps) {
   }
 
   function handleSelectTransaction() {
-    navigate(`/transaction/${transaction.ref.id}`);
+    const id = transaction.transactionRefId || transaction.ref.id;
+    navigate(`/transaction/${id}`);
+  }
+
+  function getTransactionName() {
+    let name = transaction.name;
+
+    if (transaction.installmentOrder && transaction.installmentAmount) {
+      name += ` (${transaction.installmentOrder}/${transaction.installmentAmount})`;
+    }
+    return name;
   }
 
   return (
@@ -74,7 +84,7 @@ export function TransactionRow({ transaction, onRemove }: TransactionRowProps) {
       _hover={{ bgColor: "gray.50" }}
       onClick={handleSelectTransaction}
     >
-      <Td>{transaction.name}</Td>
+      <Td>{getTransactionName()}</Td>
 
       <Td>
         {transaction.type === TransactionType.INCOME ? (

--- a/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.types.ts
+++ b/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.types.ts
@@ -21,4 +21,7 @@ export interface Transaction {
   ref: {
     id: string;
   };
+  transactionRefId?: string;
+  installmentAmount?: number;
+  installmentOrder?: number;
 }

--- a/src/features/Transaction/View/TransactionsTable/TransactionsTable.types.ts
+++ b/src/features/Transaction/View/TransactionsTable/TransactionsTable.types.ts
@@ -21,6 +21,8 @@ export interface Transaction {
     id: string;
   };
   transactionRefId?: string;
+  installmentAmount?: number;
+  installmentOrder?: number;
 }
 
 interface DocumentRef {

--- a/src/pages/Transaction/Edit/EditTransaction.tsx
+++ b/src/pages/Transaction/Edit/EditTransaction.tsx
@@ -69,8 +69,13 @@ export function EditTransaction() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (transaction) {
-      reset(transaction.data);
+    if (!transaction) return;
+
+    reset(transaction.data);
+    if (transaction.data.recurrence === TransactionRecurrence.INSTALLMENT) {
+      const installmentValue =
+        transaction.data.amount / transaction.data.installmentAmount;
+      setValue("installmentValue", Number(installmentValue.toFixed(2)));
     }
   }, [transaction, reset]);
 
@@ -214,16 +219,12 @@ export function EditTransaction() {
                   type="number"
                   label="Quantidade de parcelas"
                   error={formState.errors.installmentAmount}
-                  {...register("installmentAmount", {
-                    onChange: (e) => {
-                      const installmentAmount = Number(e.target.value);
-                      const amount =
-                        (installmentValue ?? 0) * (installmentAmount ?? 1);
-                      if (amount) {
-                        setValue("amount", Number(amount.toFixed(2)));
-                      }
-                    },
-                  })}
+                  {...register("installmentAmount")}
+                  isDisabled
+                  _disabled={{
+                    opacity: 1,
+                    cursor: "not-allowed",
+                  }}
                 />
 
                 <Input

--- a/src/pages/Transaction/Edit/EditTransaction.types.ts
+++ b/src/pages/Transaction/Edit/EditTransaction.types.ts
@@ -14,9 +14,7 @@ export interface EditTransactionFormData {
 }
 
 export type Transaction = {
-  ref: {
-    id: string;
-  };
+  ref: DocumentRef;
   data: {
     userId: string;
     name: string;
@@ -33,4 +31,12 @@ export interface UpdateTransactionsByRefIdParams {
   originalTransactionRefId: string;
   installmentTransactionRefIds?: Array<string>;
   newData: EditTransactionFormData;
+}
+
+interface DocumentRef {
+  id: string;
+}
+
+export interface GetTransactionsByTransactionRefIdResult {
+  data: Array<DocumentRef>;
 }

--- a/src/pages/Transaction/New/useNewTransaction.ts
+++ b/src/pages/Transaction/New/useNewTransaction.ts
@@ -118,6 +118,7 @@ export function useNewTransaction() {
       if (transaction.recurrence === TransactionRecurrence.INSTALLMENT) {
         installment.name = `${transaction.name} (${i}/${transaction.installmentAmount})`;
         installment.installmentOrder = i;
+        installment.installmentAmount = transaction.installmentAmount;
       }
 
       installments.push(installment);


### PR DESCRIPTION
Now it will be possible for users to edit installment transactions.

There was a breaking change in this PR that requires the database data to be reset (transactions collection). Now, the `installmentAmount` is persisted in the installment transactions too. It was made because now we transfer the responsibility of calculate/show the current installment vs total installments to the frontend instead of persisting this into transaction's name directly.