### PR TITLE
feat: info tooltip for *fixed* option in recurrence transaction

### DIFF
--- a/src/components/Form/Radio/Radio.tsx
+++ b/src/components/Form/Radio/Radio.tsx
@@ -2,23 +2,11 @@ import {
   Box,
   Radio as ChakraRadio,
   RadioGroup,
-  RadioProps as ChakraRadioProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { forwardRef } from "react";
-
-interface RadioProps extends ChakraRadioProps {
-  label: string;
-  name: string;
-  defaultValue?: string;
-  options: Option[];
-}
-
-interface Option {
-  value: string;
-  label: string;
-}
+import { RadioProps } from "./Radio.types";
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(
   ({ label, name, defaultValue, options, ...rest }, ref) => {

--- a/src/components/Form/Radio/Radio.types.ts
+++ b/src/components/Form/Radio/Radio.types.ts
@@ -1,0 +1,14 @@
+import { RadioProps as ChakraRadioProps } from "@chakra-ui/react";
+import { ReactNode } from "react";
+
+export interface RadioProps extends ChakraRadioProps {
+  label: string;
+  name: string;
+  defaultValue?: string;
+  options: Option[];
+}
+
+interface Option {
+  value: string;
+  label: string | ReactNode;
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,39 @@
+import { Tooltip as ChakraTooltip, useDisclosure } from "@chakra-ui/react";
+import { TooltipProps } from "./Tooltip.types";
+
+export function Tooltip({
+  children,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  ...rest
+}: TooltipProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  function handleClick(event: React.MouseEvent<HTMLDivElement>) {
+    onClick?.(event);
+    onClose();
+  }
+
+  function handleMouseEnter(event: React.MouseEvent<HTMLDivElement>) {
+    onMouseEnter?.(event);
+    onOpen();
+  }
+
+  function handleMouseLeave(event: React.MouseEvent<HTMLDivElement>) {
+    onMouseLeave?.(event);
+    onClose();
+  }
+
+  return (
+    <ChakraTooltip
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      isOpen={isOpen}
+      {...rest}
+    >
+      {children}
+    </ChakraTooltip>
+  );
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
-import { Tooltip as ChakraTooltip, useDisclosure } from "@chakra-ui/react";
+import { Tooltip as ChakraTooltip } from "@chakra-ui/react";
+import React, { useState } from "react";
 import { TooltipProps } from "./Tooltip.types";
 
 export function Tooltip({
@@ -8,32 +9,30 @@ export function Tooltip({
   onMouseLeave,
   ...rest
 }: TooltipProps) {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [isOpen, setIsOpen] = useState(false);
 
   function handleClick(event: React.MouseEvent<HTMLDivElement>) {
     onClick?.(event);
-    onClose();
+    setIsOpen(true);
   }
 
   function handleMouseEnter(event: React.MouseEvent<HTMLDivElement>) {
     onMouseEnter?.(event);
-    onOpen();
+    setIsOpen(true);
   }
 
   function handleMouseLeave(event: React.MouseEvent<HTMLDivElement>) {
     onMouseLeave?.(event);
-    onClose();
+    setIsOpen(false);
   }
 
   return (
-    <ChakraTooltip
-      onClick={handleClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      isOpen={isOpen}
-      {...rest}
-    >
-      {children}
+    <ChakraTooltip isOpen={isOpen} {...rest}>
+      {React.cloneElement(children as any, {
+        onClick: handleClick,
+        onMouseEnter: handleMouseEnter,
+        onMouseLeave: handleMouseLeave,
+      })}
     </ChakraTooltip>
   );
 }

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,0 +1,3 @@
+import { TooltipProps as ChakraTooltipProps } from "@chakra-ui/react";
+
+export interface TooltipProps extends ChakraTooltipProps {}

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,1 @@
+export { Tooltip } from "./Tooltip";

--- a/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.tsx
+++ b/src/features/Transaction/View/TransactionsTable/TransactionRow/TransactionRow.tsx
@@ -5,9 +5,9 @@ import {
   TagLabel,
   TagLeftIcon,
   Td,
-  Tooltip,
   Tr,
 } from "@chakra-ui/react";
+import { Tooltip } from "@components/Tooltip";
 import { useTransactionsView } from "@contexts/TransactionsViewContext";
 import { TransactionStatus } from "@shared/enums/transactionStatus";
 import { TransactionType } from "@shared/enums/transactionType";

--- a/src/pages/Transaction/New/NewTransaction.tsx
+++ b/src/pages/Transaction/New/NewTransaction.tsx
@@ -6,11 +6,11 @@ import {
   HStack,
   SimpleGrid,
   Text,
-  Tooltip,
 } from "@chakra-ui/react";
 import { Container } from "@components/Container";
 import { Input } from "@components/Form/Input";
 import { Radio } from "@components/Form/Radio/Radio";
+import { Tooltip } from "@components/Tooltip";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useCategorySuggestions } from "@hooks/useCategorySuggestions";
 import { usePaymentMethodSuggestions } from "@hooks/usePaymentMethodSuggestions";

--- a/src/pages/Transaction/New/NewTransaction.tsx
+++ b/src/pages/Transaction/New/NewTransaction.tsx
@@ -5,6 +5,8 @@ import {
   Heading,
   HStack,
   SimpleGrid,
+  Text,
+  Tooltip,
 } from "@chakra-ui/react";
 import { Container } from "@components/Container";
 import { Input } from "@components/Form/Input";
@@ -18,7 +20,7 @@ import { TransactionType } from "@shared/enums/transactionType";
 import { formatDateForFauna } from "@shared/utils/formatDateForFauna";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
-import { RxArrowLeft } from "react-icons/rx";
+import { RxArrowLeft, RxInfoCircled } from "react-icons/rx";
 import { useNavigate } from "react-router-dom";
 import * as yup from "yup";
 import { NewTransactionFormData } from "./NewTransaction.types";
@@ -200,7 +202,26 @@ export function NewTransaction() {
                     value: TransactionRecurrence.INSTALLMENT,
                     label: "Parcelado",
                   },
-                  { value: TransactionRecurrence.FIXED, label: "Fixo" },
+                  {
+                    value: TransactionRecurrence.FIXED,
+                    label: (
+                      <HStack>
+                        <Text>Fixo</Text>
+                        <Tooltip
+                          label="A transação será repetida mensalmente por 12 meses. Após esse período, ela será encerrada e você precisará cadastrá-la novamente caso queria mantê-la. Mas relaxa, vamos te avisar antes 😉"
+                          placement="top"
+                          borderRadius="md"
+                          fontSize="xs"
+                          textAlign="center"
+                          hasArrow
+                        >
+                          <Box>
+                            <RxInfoCircled size={14} />
+                          </Box>
+                        </Tooltip>
+                      </HStack>
+                    ),
+                  },
                 ]}
                 {...register("recurrence")}
               />

--- a/src/pages/Transaction/View/TransactionsView.tsx
+++ b/src/pages/Transaction/View/TransactionsView.tsx
@@ -1,12 +1,6 @@
-import {
-  Box,
-  Heading,
-  HStack,
-  Input,
-  Skeleton,
-  Tooltip,
-} from "@chakra-ui/react";
+import { Box, Heading, HStack, Input, Skeleton } from "@chakra-ui/react";
 import { Card } from "@components/Card";
+import { Tooltip } from "@components/Tooltip";
 import { useTransactionsView } from "@contexts/TransactionsViewContext";
 import { TransactionsTable } from "@features/Transaction/View/TransactionsTable";
 import { monthsName } from "@shared/constants/monthsName";


### PR DESCRIPTION
I added a tooltip with relevant information about how fixed transactions work in the _fixed_ option in recurrence field when creating a new transaction.