### PR TITLE
fix: allow change view by month even when there's no transactions in current view

### DIFF
--- a/src/pages/Transaction/View/TransactionsView.tsx
+++ b/src/pages/Transaction/View/TransactionsView.tsx
@@ -31,22 +31,6 @@ export function TransactionsView() {
     getTransactionsViewByMonth(rangeDates);
   }
 
-  if (!transactions) {
-    return (
-      <Center>
-        <Spinner color="primary.500" speed="1s" />
-      </Center>
-    );
-  }
-
-  if (transactions.length === 0) {
-    return (
-      <EmptyState>
-        Não existem transações para serem mostradas.
-      </EmptyState>
-    );
-  }
-
   return (
     <>
       <HStack
@@ -94,13 +78,30 @@ export function TransactionsView() {
         </HStack>
       </HStack>
 
-      <Card display={["none", "none", "block"]}>
-        <TransactionsTable transactions={transactions} />
-      </Card>
+      {!transactions
+        ? (
+          <Center>
+            <Spinner color="primary.500" speed="1s" />
+          </Center>
+        )
+        : transactions.length === 0
+          ? (
+            <EmptyState>
+              Não existem transações para serem mostradas.
+            </EmptyState>
+          )
+          : (
+            <>
+              <Card display={["none", "none", "block"]}>
+                <TransactionsTable transactions={transactions} />
+              </Card>
 
-      <Card display={["flex", "flex", "none"]} p={0}>
-        <TransactionsList transactions={transactions} />
-      </Card>
+              <Card display={["flex", "flex", "none"]} p={0}>
+                <TransactionsList transactions={transactions} />
+              </Card>
+            </>
+          )
+      }
     </>
   );
 }


### PR DESCRIPTION
This PR takes a bugfix for transactions view. The page didn't let the user change the transactions view by month when the current view has no transactions. Now users can change the view by month in all cases.